### PR TITLE
Adding UDP + IPv6 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![logo](https://github.com/landhb/DrawBridge/blob/master/img/logo.PNG?raw=true)
 
-A layer 4 Single Packet Authentication (SPA) Module, used to conceal TCP ports on public facing machines and add an extra layer of security. 
+A layer 4 Single Packet Authentication (SPA) Module, used to conceal TCP/UDP ports on public facing machines and add an extra layer of security. 
+
+Note: DrawBridge now supports both IPv4 and IPv6 traffic
 
 ## Demo
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -10,6 +10,7 @@ PWD := $(shell pwd)
 default:
 ifneq ("$(wildcard ./key.h)","")
 	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules
+	rm -fr *.o .*.cmd Module.symvers modules.order drawbridge.mod.c
 else
 	@echo "[!] Please ensure you've generated a public key, and that key.h is in this directory"
 endif

--- a/kernel/drawbridge.h
+++ b/kernel/drawbridge.h
@@ -6,6 +6,7 @@
 #include <linux/if_ether.h>
 #include <linux/icmp.h>
 #include <linux/ip.h>
+#include <linux/ipv6.h>
 #include <linux/in.h>
 #include <linux/tcp.h>
 

--- a/kernel/drawbridge.h
+++ b/kernel/drawbridge.h
@@ -61,15 +61,13 @@ typedef struct conntrack_state {
 
 // Must be packed so that the compiler doesn't byte align the structure
 struct packet {
-	struct ethhdr eth_h;
-	struct iphdr ip_h;
-	struct tcphdr tcp_h;
 
 	// Protocol data
 	struct timespec timestamp;
 	__be16 port;
 
 } __attribute__( ( packed ) ); 
+
 
 
 // Typdefs for cleaner code

--- a/kernel/drawbridge.h
+++ b/kernel/drawbridge.h
@@ -19,6 +19,10 @@
 // Time
 #include <linux/time.h>
 
+// Timout Configuration
+#define STATE_TIMEOUT 60000
+
+// Defaults
 #define MAX_PACKET_SIZE 65535
 #define MAX_SIG_SIZE 4096
 #define MAX_DIGEST_SIZE 256
@@ -46,8 +50,8 @@ typedef struct conntrack_state {
 
 	// Source IP
 	union {
-		__be32 addr_4;
 		struct in6_addr addr_6;
+		__be32 addr_4;
 	} src;
 
 	// Timestamp
@@ -83,6 +87,7 @@ void inet_ntoa(char * str_ip, __be32 int_ip);
 conntrack_state	* init_state(void);
 int state_lookup(conntrack_state * head, int type, __be32 src, struct in6_addr * src_6, __be16 port);
 void state_add(conntrack_state ** head, int type, __be32 src, struct in6_addr * src_6, __be16 port);
+void cleanup_states(conntrack_state * head);
 
 // Connection Reaper API
 void reap_expired_connections(unsigned long timeout);

--- a/kernel/xt_crypto.c
+++ b/kernel/xt_crypto.c
@@ -294,7 +294,7 @@ int verify_sig_rsa(akcipher_request * req, pkey_signature * sig) {
 		return -EKEYREJECTED;
 	}
 		
-	printk(KERN_INFO "[+] RSA signature verification passed\n");
+	//printk(KERN_INFO "[+] RSA signature verification passed\n");
 	kfree(inbuf);
 	kfree(outbuf);
 	return 0;

--- a/kernel/xt_crypto.c
+++ b/kernel/xt_crypto.c
@@ -1,7 +1,7 @@
 /*
 	Project: DrawBridge
-	Description: Assymetric crypto wrapper API for Single Packet Authentication
-	Auther: Bradley Landherr
+	Description: Asymmetric crypto wrapper API for Single Packet Authentication
+	Author: Bradley Landherr
 */
 
 #include <linux/module.h>

--- a/kernel/xt_hook.c
+++ b/kernel/xt_hook.c
@@ -173,7 +173,7 @@ static struct nf_hook_ops pkt_hook_ops __read_mostly	= {
 
 static struct nf_hook_ops pkt_hook_ops_v6 __read_mostly	= {
 	.pf 		= NFPROTO_IPV6,
-	.priority	= 1,
+	.priority	= 2,
 	.hooknum	= NF_INET_LOCAL_IN,
 	.hook		= &pkt_hook_v6,
 };
@@ -237,9 +237,11 @@ static int __init nf_conntrack_knock_init(void) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
 	ret = nf_register_net_hook(&init_net, &pkt_hook_ops);
 	ret6 = nf_register_net_hook(&init_net, &pkt_hook_ops_v6);
+	ret6 = 0;
 #else
 	ret = nf_register_hook(&pkt_hook_ops);
 	ret6 = nf_register_hook(&pkt_hook_ops_v6);
+	ret6 = 0;
 #endif
 
 	if(ret || ret6) {
@@ -284,8 +286,10 @@ static void __exit nf_conntrack_knock_exit(void) {
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
 	nf_unregister_net_hook(&init_net, &pkt_hook_ops);
+	nf_unregister_net_hook(&init_net, &pkt_hook_ops_v6);
 #else
 	nf_unregister_hook(&pkt_hook_ops);
+	nf_unregister_hook(&pkt_hook_ops_v6);
 #endif
 
 	printk(KERN_INFO "[*] Unloaded Knock Netfilter module from kernel\n");

--- a/kernel/xt_hook.c
+++ b/kernel/xt_hook.c
@@ -30,8 +30,8 @@ MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Bradley Landherr https://github.com/landhb");
 MODULE_DESCRIPTION("NetFilter Kernel Module to Support BPF Based Single Packet Authentication");
 MODULE_VERSION("0.1");
-MODULE_ALIAS("trigger");
-MODULE_ALIAS("ip_conntrack_trigger");
+MODULE_ALIAS("drawbridge");
+MODULE_ALIAS("ip_conntrack_drawbridge");
 
 
 

--- a/kernel/xt_hook.c
+++ b/kernel/xt_hook.c
@@ -210,7 +210,7 @@ void reap_expired_connections(unsigned long timeout) {
 // Init function to register target
 static int __init nf_conntrack_knock_init(void) {
 
-	int ret;
+	int ret, ret6;
 	raw_thread = NULL;
 	reaper = NULL;
 
@@ -236,11 +236,13 @@ static int __init nf_conntrack_knock_init(void) {
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
 	ret = nf_register_net_hook(&init_net, &pkt_hook_ops);
+	ret6 = nf_register_net_hook(&init_net, &pkt_hook_ops_v6);
 #else
 	ret = nf_register_hook(&pkt_hook_ops);
+	ret6 = nf_register_hook(&pkt_hook_ops_v6);
 #endif
 
-	if(ret) {
+	if(ret || ret6) {
 		printk(KERN_INFO "[-] Failed to register hook\n");
 		return ret;
 	} 

--- a/kernel/xt_listen.c
+++ b/kernel/xt_listen.c
@@ -89,7 +89,6 @@ static int ksocket_receive(struct socket* sock, struct sockaddr_in* addr, unsign
 	struct msghdr msg;
 	mm_segment_t oldfs;
 	int size = 0;
-	//struct iov_iter iov;
 	struct iovec iov;
 
 	if (sock->sk == NULL) return 0;
@@ -106,9 +105,6 @@ static int ksocket_receive(struct socket* sock, struct sockaddr_in* addr, unsign
 	msg.msg_iocb = NULL;
 
 	iov_iter_init(&msg.msg_iter, WRITE, &iov, 1, len);
-	//msg.msg_iter.iov->iov_base = buf;
-	//msg.msg_iter.iov->iov_len = len;
-	//msg.msg_iovlen=1;
 
 	oldfs = get_fs();
 	set_fs(KERNEL_DS);
@@ -321,7 +317,6 @@ int listen(void * data) {
 		remove_wait_queue(&sock->sk->sk_wq->wait, &recv_wait);
 
 		memset(pkt, 0, MAX_PACKET_SIZE);
-		memset(src, 0, 32+1);
 		if((recv_len = ksocket_receive(sock, &source, pkt, MAX_PACKET_SIZE)) > 0) {
 
 			if (recv_len < sizeof(struct packet)) {

--- a/kernel/xt_listen.c
+++ b/kernel/xt_listen.c
@@ -308,12 +308,10 @@ int listen(void * data) {
 				offset = sizeof(struct ethhdr) + sizeof(struct ipv6hdr) + sizeof(struct tcphdr) + sizeof(struct packet);
 			} 
 			
-
-			res = (struct packet *)(pkt + offset);
 			
 			// Process packet
 			printk(KERN_INFO "[+] Got packet!   len:%d    from:%s\n", recv_len, src);
-
+			res = (struct packet *)(pkt + offset - sizeof(struct packet));
 
 			// Parse the packet for a signature
 			sig = get_signature(pkt, offset);

--- a/kernel/xt_listen.c
+++ b/kernel/xt_listen.c
@@ -1,7 +1,7 @@
 /*
 	Project: DrawBridge
 	Description: Raw socket listener to support Single Packet Authentication
-	Auther: Bradley Landherr
+	Author: Bradley Landherr
 */
 
 #include <linux/kernel.h>
@@ -47,10 +47,8 @@ void inet_ntoa(char * str_ip, __be32 int_ip)
 
 	if(!str_ip)
 		return;
-	else
-		memset(str_ip, 0, 16);
 
-
+	memset(str_ip, 0, 16);
 	sprintf(str_ip, "%d.%d.%d.%d", (int_ip) & 0xFF, (int_ip >> 8) & 0xFF,
 							(int_ip >> 16) & 0xFF, (int_ip >> 24) & 0xFF);
 

--- a/kernel/xt_state.c
+++ b/kernel/xt_state.c
@@ -15,6 +15,9 @@ extern spinlock_t listmutex;
 
 static inline int ipv6_addr_cmp(const struct in6_addr *a1, const struct in6_addr *a2)
 {
+	if(a2 == NULL || a1 == NULL){
+		return -1;
+	}
 	return memcmp(a1, a2, sizeof(struct in6_addr));
 }
 

--- a/kernel/xt_state.c
+++ b/kernel/xt_state.c
@@ -87,6 +87,24 @@ void state_add(conntrack_state ** head, int type, __be32 src, struct in6_addr * 
 	return;
 }
 
+void cleanup_states(conntrack_state * head) {
+
+	conntrack_state	 * state, *tmp;
+	
+	spin_lock(&listmutex);
+
+	list_for_each_entry_safe(state, tmp, &(head->list), list) {
+
+		list_del_rcu(&(state->list));
+		spin_unlock(&listmutex);
+		kfree(state);
+		spin_lock(&listmutex);
+		
+	}
+
+	spin_unlock(&listmutex);
+}
+
 
 /* -----------------------------------------------
 				Reaper Timeout Functions


### PR DESCRIPTION
Changelog:

- Updates the BPF filter to parse IPv6 packets (xt_listen.c)
- Updates the raw socket listener to parse IPv6 triggers (xt_listen.c)
- Updates the packet structure to not be protocol dependent (drawbridge.h)
- Adds `pkt_hook_v6` and generalizes connection checks in `conn_state_check` (xt_hook.c)
- UDP packets will now be parsed in `pkt_hook_v6` and `pkt_hook_v4` (xt_hook.c)
- Client code now supports sending IPv6 triggers (client/bridge.c)