### PR TITLE
bugfix ipv6_addr_cmp return condition wrong

### DIFF
--- a/module/src/state.c
+++ b/module/src/state.c
@@ -62,7 +62,7 @@ static inline int compare_state_info(struct conntrack_state *state, parsed_packe
         case 4:
             return state->src.addr_4 == info->ip.addr_4;
         case 6:
-            return ipv6_addr_cmp(&state->src.addr_6, &info->ip.addr_6);
+            return ipv6_addr_cmp(&state->src.addr_6, &info->ip.addr_6) == 0;
         default:
             return -1;
     }


### PR DESCRIPTION
Signed-off-by: Xiaobo Liu <cppcoffee@gmail.com>

ipv6_addr_cmp on match return zero, compare_state_info match return 1. so we need change to `ipv6_addr_cmp(&state->src.addr_6, &info->ip.addr_6) == 0`