### PR TITLE
Remove extra listmutex variable definition

### DIFF
--- a/module/src/state.c
+++ b/module/src/state.c
@@ -23,7 +23,6 @@ conntrack_state *knock_state;
 /*
  * Globally access mutex to protect the list
  */
-spinlock_t listmutex;
 DEFINE_SPINLOCK(listmutex);
 
 /*


### PR DESCRIPTION
Signed-off-by: Xiaobo Liu <cppcoffee@gmail.com>