### PR TITLE
Use the std library instead of unsafe libc call

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -81,7 +81,6 @@ name = "dbtools"
 version = "1.0.3"
 dependencies = [
  "clap",
- "libc",
  "openssl",
  "pnet",
  "rand",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -22,7 +22,6 @@ path = "src/main.rs"
 
 [dependencies]
 pnet = "0.28.0"
-libc = "0.2.132"
 rand = "0.8.5"
 clap = "3.2.22"
 ring = "0.16.20"

--- a/tools/src/drawbridge.rs
+++ b/tools/src/drawbridge.rs
@@ -38,10 +38,7 @@ pub fn build_packet<'a>(
         return Err(DoesNoteExist.into());
     }
 
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+    let secs = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
 
     // initialize the Drawbridge protocol data
     let mut data = DrawBridgeData {

--- a/tools/src/drawbridge.rs
+++ b/tools/src/drawbridge.rs
@@ -1,6 +1,7 @@
 use crate::errors::DrawBridgeError::*;
 use std::error::Error;
 use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::crypto;
 
@@ -37,21 +38,15 @@ pub fn build_packet<'a>(
         return Err(DoesNoteExist.into());
     }
 
-    // Init tempsepc
-    let mut timestamp = libc::timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-
-    // get current timestamp
-    unsafe {
-        libc::clock_gettime(libc::CLOCK_REALTIME, &mut timestamp);
-    }
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
 
     // initialize the Drawbridge protocol data
     let mut data = DrawBridgeData {
         port: unlock_port,
-        timestamp: timestamp.tv_sec,
+        timestamp: secs as i64,
     }
     .to_network_vec();
 


### PR DESCRIPTION
Compatible with Windows get time call

Signed-off-by: Xiaobo Liu <cppcoffee@gmail.com>