### PR TITLE
Use the atomic operation time_updated variable

### DIFF
--- a/module/include/drawbridge.h
+++ b/module/include/drawbridge.h
@@ -55,7 +55,7 @@ typedef struct conntrack_state {
 
     // Timestamps
     unsigned long time_added;
-    unsigned long time_updated;
+    atomic64_t time_updated;
 
     // List entry
     struct list_head list;


### PR DESCRIPTION
Then update state use atomic64_t instead of create new node, to avoid rcu and spin lock operator.

Signed-off-by: Xiaobo Liu <cppcoffee@gmail.com>